### PR TITLE
refactor(core): split PlatformAdapter into FrameScheduler and CanvasFactory

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ import {
   RenderPath,
   RenderChunk,
 } from './rendering'
+import type { IFrameScheduler } from './platform'
 
 export type ElementType =
   | 'View'
@@ -40,7 +41,7 @@ export type ElementType =
 export function createElement(type: 'View'): RenderView
 export function createElement(type: 'Chunk'): RenderChunk
 export function createElement(type: 'Flex'): RenderFlex
-export function createElement(type: 'Canvas'): RenderCanvas
+export function createElement(type: 'Canvas', frameScheduler?: IFrameScheduler): RenderCanvas
 export function createElement(type: 'Rect'): RenderRect
 export function createElement(type: 'RRect'): RenderRRect
 export function createElement(type: 'Circle'): RenderCircle
@@ -53,7 +54,7 @@ export function createElement(type: 'Image'): RenderImage
 // see https://github.com/microsoft/TypeScript/issues/14107
 export function createElement(type: ElementType): RenderObject
 
-export function createElement(type: ElementType): RenderObject {
+export function createElement(type: ElementType, frameScheduler?: IFrameScheduler): RenderObject {
   if (type === 'View') {
     return new RenderView()
   } if (type === 'Chunk') {
@@ -61,7 +62,7 @@ export function createElement(type: ElementType): RenderObject {
   } else if (type === 'Flex') {
     return new RenderFlex()
   } else if (type === 'Canvas') {
-    return new RenderCanvas()
+    return new RenderCanvas(frameScheduler)
   } else if (type === 'Rect') {
     return new RenderRect()
   } else if (type === 'RRect') {

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -7,9 +7,29 @@ export type CrossPlatformCanvasOrOffscreenCanvas = CrossPlatformCanvasElement | 
 
 export type FrameCallback = (ms: number) => void
 
-export interface IPlatformAdapter {
+/**
+ * Interface for frame scheduling (requestAnimationFrame-like functionality).
+ * Separates frame scheduling concerns from canvas creation.
+ */
+export interface IFrameScheduler {
+  /**
+   * Request that a frame be scheduled
+   */
   scheduleFrame(): void
+
+  /**
+   * Register a callback to be invoked on each frame
+   * @param callback Function to call on each frame with timestamp
+   * @returns Cleanup function to unregister the callback
+   */
   onFrame(callback: FrameCallback): () => void
+}
+
+/**
+ * Interface for canvas creation and management.
+ * Separates canvas lifecycle concerns from frame scheduling.
+ */
+export interface ICanvasFactory {
   createCanvas(width: number, height: number): CrossPlatformCanvasElement
   createOffscreenCanvas(width: number, height: number): CrossPlatformCanvasOrOffscreenCanvas
   createRenderingContext(width: number, height: number): CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null
@@ -19,3 +39,9 @@ export interface IPlatformAdapter {
   ): void
   readonly supportOffscreenCanvas: boolean
 }
+
+/**
+ * Combined platform adapter interface for backward compatibility.
+ * Implements both frame scheduling and canvas creation.
+ */
+export interface IPlatformAdapter extends IFrameScheduler, ICanvasFactory {}


### PR DESCRIPTION
Hello!  I've adapted your project to build user interfaces in WebXR.   This is one of a few PRs with the over all goal of:

- use the WebXR render loop and not use RAF
- allow events to be injected into Canvas UI, useful for automated tested and also useful in WebXR to bridge events from WebXR into the canvas-ui
- Create a `<HeadlessCanvas />` that takes an offscreencanvas and renders to it, which for webXR we then copy to a texture to be displayed.

I'm making a set of smaller PRs so they are easier to review. 

This separates frame scheduling concerns from canvas creation for better architectural clarity and simpler custom integrations (e.g., WebXR).

Changes:
- Split IPlatformAdapter into two focused interfaces:
  * IFrameScheduler - Frame scheduling (scheduleFrame, onFrame)
  * ICanvasFactory - Canvas creation and management
- Update RenderCanvas to depend only on IFrameScheduler
  * Rename parameter from platformAdapter to frameScheduler
  * RenderCanvas no longer depends on canvas creation methods
- Update createElement factory to accept IFrameScheduler
- Keep IPlatformAdapter as union of both for backward compatibility

Benefits:
- Single Responsibility Principle - each interface has one concern
- RenderCanvas only depends on what it needs (frame scheduling)
- WebXR/custom renderers can provide simple IFrameScheduler without implementing unused canvas creation methods
- No breaking changes - IPlatformAdapter still works as before
- Better foundation for testing