### PR TITLE
Injectable bindings and bridge

### DIFF
--- a/packages/core/src/events/__tests__/bridge-event-binding.spec.ts
+++ b/packages/core/src/events/__tests__/bridge-event-binding.spec.ts
@@ -1,0 +1,274 @@
+import { BridgeEventBinding, SyntheticEventManager } from '..'
+import { RenderCanvas } from '../../rendering'
+import { createElement } from '../../index'
+import { Point, Size } from '../../math'
+
+// Mock FrameScheduler for tests
+const createMockFrameScheduler = () => {
+  const callbacks: Array<(ms: number) => void> = []
+  return {
+    scheduleFrame: () => {
+      // Immediately flush all callbacks
+      callbacks.forEach(cb => cb(performance.now()))
+    },
+    onFrame: (callback: (ms: number) => void) => {
+      callbacks.push(callback)
+      return () => {
+        const index = callbacks.indexOf(callback)
+        if (index !== -1) callbacks.splice(index, 1)
+      }
+    }
+  }
+}
+
+describe('BridgeEventBinding', () => {
+  describe('Unit Tests', () => {
+    test('injectPointerEvent adds event to buffer', () => {
+      const binding = new BridgeEventBinding()
+
+      binding.injectPointerEvent('pointerdown', 100, 50, 0, 0)
+
+      const events = binding.flushPointerEvents()
+      expect(events[0]).toBeDefined()
+      expect(events[0].pointerdown).toBeDefined()
+      expect(events[0].pointerdown?.offsetX).toBe(100)
+      expect(events[0].pointerdown?.offsetY).toBe(50)
+    })
+
+    test('flushPointerEvents clears buffer', () => {
+      const binding = new BridgeEventBinding()
+
+      binding.injectPointerEvent('pointerdown', 100, 50)
+      binding.flushPointerEvents()
+
+      const events = binding.flushPointerEvents()
+      expect(events).toEqual({})
+    })
+
+    test('onEvents callback fires on injection', () => {
+      const binding = new BridgeEventBinding()
+      const onEvents = jest.fn()
+      binding.onEvents = onEvents
+
+      binding.injectPointerEvent('pointermove', 10, 20)
+
+      expect(onEvents).toHaveBeenCalledTimes(1)
+    })
+
+    test('supports multiple pointer IDs', () => {
+      const binding = new BridgeEventBinding()
+
+      binding.injectPointerEvent('pointerdown', 10, 20, 0, 0)
+      binding.injectPointerEvent('pointerdown', 50, 60, 0, 1)
+
+      const events = binding.flushPointerEvents()
+      expect(events[0]?.pointerdown?.offsetX).toBe(10)
+      expect(events[1]?.pointerdown?.offsetX).toBe(50)
+    })
+
+    test('injectWheelEvent adds wheel event', () => {
+      const binding = new BridgeEventBinding()
+
+      binding.injectWheelEvent(100, 50, 0, -10)
+
+      expect(binding.hasWheelEvent).toBe(true)
+      const event = binding.flushWheelEvent()
+      expect(event?.deltaY).toBe(-10)
+    })
+  })
+
+  describe('Integration Tests with Core API', () => {
+    let canvas: RenderCanvas
+    let bridgeBinding: BridgeEventBinding
+    let eventManager: SyntheticEventManager
+
+    beforeEach(() => {
+      // Create RenderCanvas with BridgeEventBinding injected
+      bridgeBinding = new BridgeEventBinding()
+      canvas = new RenderCanvas(
+        createMockFrameScheduler(),
+        bridgeBinding
+      )
+      canvas.prepareInitialFrame()
+      canvas.offstage = false
+      canvas.size = Size.fromWH(800, 600)
+
+      // Get event manager
+      eventManager = SyntheticEventManager.findInstance(canvas)!
+    })
+
+    afterEach(() => {
+      canvas.dispose()
+    })
+
+    test('injected pointerdown event reaches element handler', () => {
+      const handleClick = jest.fn()
+
+      // Create UI using explicit positioning
+      const rect = createElement('Rect')
+      rect.offstage = false
+      rect.size = Size.fromWH(100, 50)
+      rect.offset = Point.fromXY(50, 50)
+      rect.addEventListener('pointerdown', handleClick)
+      canvas.child = rect
+
+      // Inject click inside bounds
+      bridgeBinding.injectPointerEvent('pointerdown', 75, 60)
+      eventManager.flushNativeEvents()
+
+      expect(handleClick).toHaveBeenCalled()
+      expect(handleClick.mock.calls[0][0].type).toBe('pointerdown')
+    })
+
+    test('events outside bounds do not trigger handlers (hit testing)', () => {
+      const handleClick = jest.fn()
+
+      const rect = createElement('Rect')
+      rect.offstage = false
+      rect.size = Size.fromWH(100, 50)
+      rect.offset = Point.fromXY(50, 50)
+      rect.addEventListener('pointerdown', handleClick)
+      canvas.child = rect
+
+      // Inject click outside bounds
+      bridgeBinding.injectPointerEvent('pointerdown', 10, 10)
+      eventManager.flushNativeEvents()
+
+      expect(handleClick).not.toHaveBeenCalled()
+    })
+
+    test('pointermove generates pointerenter event on hover', () => {
+      const handleEnter = jest.fn()
+
+      const rect = createElement('Rect')
+      rect.offstage = false
+      rect.size = Size.fromWH(100, 50)
+      rect.offset = Point.fromXY(50, 50)
+      rect.addEventListener('pointerenter', handleEnter)
+      canvas.child = rect
+
+      // First move outside to establish a previous path
+      bridgeBinding.injectPointerEvent('pointermove', 10, 10)
+      eventManager.flushNativeEvents()
+
+      // Then move into bounds - this triggers pointerenter
+      bridgeBinding.injectPointerEvent('pointermove', 75, 60)
+      eventManager.flushNativeEvents()
+
+      expect(handleEnter).toHaveBeenCalled()
+    })
+
+    test('pointermove generates pointerleave event when leaving', () => {
+      const handleLeave = jest.fn()
+
+      const rect = createElement('Rect')
+      rect.offstage = false
+      rect.size = Size.fromWH(100, 50)
+      rect.offset = Point.fromXY(50, 50)
+      rect.addEventListener('pointerleave', handleLeave)
+      canvas.child = rect
+
+      // Move into bounds
+      bridgeBinding.injectPointerEvent('pointermove', 75, 60)
+      eventManager.flushNativeEvents()
+
+      // Move out of bounds
+      bridgeBinding.injectPointerEvent('pointermove', 10, 10)
+      eventManager.flushNativeEvents()
+
+      expect(handleLeave).toHaveBeenCalled()
+    })
+
+    test('events bubble through component hierarchy', () => {
+      const handleOuterClick = jest.fn()
+      const handleInnerClick = jest.fn()
+
+      const outer = createElement('View') as any
+      outer.offstage = false
+      outer.size = Size.fromWH(200, 200)
+      outer.offset = Point.fromXY(50, 50)
+      outer.addEventListener('pointerdown', handleOuterClick)
+
+      const inner = createElement('Rect')
+      inner.offstage = false
+      inner.size = Size.fromWH(100, 100)
+      inner.offset = Point.fromXY(25, 25)
+      inner.addEventListener('pointerdown', handleInnerClick)
+
+      outer.appendChild(inner)
+      canvas.child = outer
+
+      // Click on inner element (absolute position: 50+25=75, 50+25=75)
+      bridgeBinding.injectPointerEvent('pointerdown', 100, 100)
+      eventManager.flushNativeEvents()
+
+      expect(handleInnerClick).toHaveBeenCalled()
+      expect(handleOuterClick).toHaveBeenCalled() // Bubbled
+    })
+
+    test('wheel events trigger scroll handlers', () => {
+      const handleWheel = jest.fn()
+
+      const rect = createElement('Rect')
+      rect.offstage = false
+      rect.size = Size.fromWH(100, 50)
+      rect.offset = Point.fromXY(50, 50)
+      rect.addEventListener('wheel', handleWheel)
+      canvas.child = rect
+
+      // Inject wheel event
+      bridgeBinding.injectWheelEvent(75, 60, 0, -10)
+      eventManager.flushNativeEvents()
+
+      expect(handleWheel).toHaveBeenCalled()
+      expect(handleWheel.mock.calls[0][0].deltaY).toBe(-10)
+    })
+
+    test('complex UI tree with multiple event handlers', () => {
+      const handleButton1 = jest.fn()
+      const handleButton2 = jest.fn()
+      const handleHover = jest.fn()
+
+      const container = createElement('View') as any
+      container.offstage = false
+      container.size = Size.fromWH(800, 600)
+      container.offset = Point.fromXY(0, 0)
+
+      const button1 = createElement('Rect')
+      button1.offstage = false
+      button1.size = Size.fromWH(200, 50)
+      button1.offset = Point.fromXY(0, 0)
+      button1.addEventListener('pointerdown', handleButton1)
+      button1.addEventListener('pointerenter', handleHover)
+
+      const button2 = createElement('Rect')
+      button2.offstage = false
+      button2.size = Size.fromWH(200, 50)
+      button2.offset = Point.fromXY(0, 50)
+      button2.addEventListener('pointerdown', handleButton2)
+
+      container.appendChild(button1)
+      container.appendChild(button2)
+      canvas.child = container
+
+      // First move outside to establish previous path
+      bridgeBinding.injectPointerEvent('pointermove', 300, 300)
+      eventManager.flushNativeEvents()
+
+      // Hover over button 1 - this triggers pointerenter
+      bridgeBinding.injectPointerEvent('pointermove', 100, 25)
+      eventManager.flushNativeEvents()
+      expect(handleHover).toHaveBeenCalled()
+
+      // Click button 1
+      bridgeBinding.injectPointerEvent('pointerdown', 100, 25)
+      eventManager.flushNativeEvents()
+      expect(handleButton1).toHaveBeenCalled()
+
+      // Click button 2 (y offset: 50px down)
+      bridgeBinding.injectPointerEvent('pointerdown', 100, 75)
+      eventManager.flushNativeEvents()
+      expect(handleButton2).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/events/bridge-event-binding.ts
+++ b/packages/core/src/events/bridge-event-binding.ts
@@ -1,0 +1,155 @@
+import type { NativeEventBinding, NativePointerEvents } from '../events/types'
+
+/**
+ * BridgeEventBinding - A NativeEventBinding implementation for programmatic
+ * event injection.
+ *
+ * This class bridges external event sources (XR controller events, test
+ * playback) to Canvas UI's event processing system.  Unlike DOMEventBinding
+ * which listens to DOM events, BridgeEventBinding allows manual injection
+ * of events programmatically.
+ *
+ * Usage:
+ * ```ts
+ * const bridgeBinding = new BridgeEventBinding()
+ *
+ * // Pass to RenderCanvas constructor (recommended)
+ * const canvas = new RenderCanvas(undefined, bridgeBinding)
+ * canvas.prepareInitialFrame()
+ *
+ * // Later, inject events:
+ * bridgeBinding.injectPointerEvent('pointermove', x, y, 0, 0)
+ * bridgeBinding.injectPointerEvent('pointerdown', x, y, 0, 0)
+ * ```
+ */
+export class BridgeEventBinding implements NativeEventBinding {
+  private pointerEventsBuffer: NativePointerEvents = {}
+  private wheelEvent?: WheelEvent
+  private _el?: HTMLElement
+
+  /**
+   * Callback invoked when events are added to the buffer.
+   * Canvas UI uses this to schedule frame rendering.
+   */
+  onEvents?: () => void
+
+  /**
+   * Always returns true since programmatic binding is always "bound"
+   */
+  get bound() {
+    return true
+  }
+
+  /**
+   * No-op element setter - BridgeEventBinding doesn't use DOM elements
+   */
+  get el() {
+    return this._el
+  }
+  set el(value) {
+    this._el = value
+  }
+
+  /**
+   * Check if there's a wheel event in the buffer
+   */
+  get hasWheelEvent() {
+    return !!this.wheelEvent
+  }
+
+  /**
+   * Inject a pointer event programmatically.
+   *
+   * @param type - Event type (pointermove, pointerdown, pointerup, pointerenter, pointerleave)
+   * @param x - X coordinate in canvas space (offsetX)
+   * @param y - Y coordinate in canvas space (offsetY)
+   * @param button - Mouse button (0 = left, 1 = middle, 2 = right)
+   * @param pointerId - Pointer ID for multi-touch (default 0)
+   */
+  injectPointerEvent(
+    type: 'pointermove' | 'pointerdown' | 'pointerup' | 'pointerenter' | 'pointerleave',
+    x: number,
+    y: number,
+    button: number = 0,
+    pointerId: number = 0
+  ) {
+    // Create a synthetic PointerEvent-like object
+    const event = {
+      type,
+      offsetX: x,
+      offsetY: y,
+      button,
+      pointerId,
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+      movementX: 0,
+      movementY: 0,
+      timeStamp: performance.now(),
+    } as PointerEvent
+
+    // Add to buffer, keyed by pointerId
+    if (!this.pointerEventsBuffer[pointerId]) {
+      this.pointerEventsBuffer[pointerId] = {}
+    }
+    this.pointerEventsBuffer[pointerId][type] = event
+
+    // Notify that events are available (triggers frame scheduling)
+    this.onEvents?.()
+  }
+
+  /**
+   * Inject a wheel (scroll) event programmatically.
+   *
+   * @param x - X coordinate in canvas space
+   * @param y - Y coordinate in canvas space
+   * @param deltaX - Horizontal scroll amount
+   * @param deltaY - Vertical scroll amount
+   * @param deltaMode - Delta mode (0 = pixels, 1 = lines, 2 = pages)
+   */
+  injectWheelEvent(
+    x: number,
+    y: number,
+    deltaX: number,
+    deltaY: number,
+    deltaMode: number = 0
+  ) {
+    // Create a synthetic WheelEvent-like object
+    this.wheelEvent = {
+      type: 'wheel',
+      offsetX: x,
+      offsetY: y,
+      deltaX,
+      deltaY,
+      deltaZ: 0,
+      deltaMode,
+      bubbles: true,
+      cancelable: true,
+      timeStamp: performance.now(),
+    } as WheelEvent
+
+    // Notify that events are available
+    this.onEvents?.()
+  }
+
+  /**
+   * Flush all buffered pointer events and clear the buffer.
+   * Called by SyntheticEventManager during event processing.
+   */
+  flushPointerEvents(): NativePointerEvents {
+    const buffer = this.pointerEventsBuffer
+    this.pointerEventsBuffer = {}
+    return buffer
+  }
+
+  /**
+   * Flush the buffered wheel event and clear it.
+   * Called by SyntheticEventManager during event processing.
+   */
+  flushWheelEvent(): WheelEvent | undefined {
+    const event = this.wheelEvent
+    this.wheelEvent = undefined
+    return event
+  }
+}

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,3 +1,4 @@
+export * from './bridge-event-binding'
 export * from './dom-event-binding'
 export * from './synthetic-event'
 export * from './synthetic-event-manager'

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -46,6 +46,11 @@ export interface NativeEventBinding {
    * 检查当前绑定是否已绑定
    */
   readonly bound: boolean
+
+  /**
+   * Canvas element to bind events to
+   */
+  el?: HTMLElement | undefined
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ import {
   RenderChunk,
 } from './rendering'
 import type { IFrameScheduler } from './platform'
+import type { NativeEventBinding } from './events'
 
 export type ElementType =
   | 'View'
@@ -41,7 +42,7 @@ export type ElementType =
 export function createElement(type: 'View'): RenderView
 export function createElement(type: 'Chunk'): RenderChunk
 export function createElement(type: 'Flex'): RenderFlex
-export function createElement(type: 'Canvas', frameScheduler?: IFrameScheduler): RenderCanvas
+export function createElement(type: 'Canvas', frameScheduler?: IFrameScheduler, binding?: NativeEventBinding): RenderCanvas
 export function createElement(type: 'Rect'): RenderRect
 export function createElement(type: 'RRect'): RenderRRect
 export function createElement(type: 'Circle'): RenderCircle
@@ -54,7 +55,7 @@ export function createElement(type: 'Image'): RenderImage
 // see https://github.com/microsoft/TypeScript/issues/14107
 export function createElement(type: ElementType): RenderObject
 
-export function createElement(type: ElementType, frameScheduler?: IFrameScheduler): RenderObject {
+export function createElement(type: ElementType, frameScheduler?: IFrameScheduler, binding?: NativeEventBinding): RenderObject {
   if (type === 'View') {
     return new RenderView()
   } if (type === 'Chunk') {
@@ -62,7 +63,7 @@ export function createElement(type: ElementType, frameScheduler?: IFrameSchedule
   } else if (type === 'Flex') {
     return new RenderFlex()
   } else if (type === 'Canvas') {
-    return new RenderCanvas(frameScheduler)
+    return new RenderCanvas(frameScheduler, binding)
   } else if (type === 'Rect') {
     return new RenderRect()
   } else if (type === 'RRect') {

--- a/packages/core/src/rendering/render-canvas.ts
+++ b/packages/core/src/rendering/render-canvas.ts
@@ -3,6 +3,7 @@ import { LayerTree, Rasterizer, TransformLayer } from '../compositing'
 import {
   DOMEventBinding,
   HitTestRoot,
+  NativeEventBinding,
   SyntheticEvent,
   SyntheticEventManager,
   SyntheticPointerEvent
@@ -19,7 +20,7 @@ import { RenderSingleChild } from './render-single-child'
 
 /**
  * 渲染树的根节点，负责各类初始化和渲染管线工作
- * 
+ *
  * RenderCanvas 持有唯一子节点 RenderObject
  */
 export class RenderCanvas
@@ -32,7 +33,7 @@ export class RenderCanvas
 
   private clearOnFrame: () => void
 
-  private nativeEventBinding: DOMEventBinding
+  private nativeEventBinding: NativeEventBinding
 
   private frameScheduler: IFrameScheduler
 
@@ -43,7 +44,10 @@ export class RenderCanvas
 
   private frameDirty = false
 
-  constructor(frameScheduler: IFrameScheduler = PlatformAdapter) {
+  constructor(
+    frameScheduler: IFrameScheduler = PlatformAdapter,
+    binding?: NativeEventBinding
+  ) {
     super()
     this.frameScheduler = frameScheduler
     this.pipeline = new RenderPipeline(this.handleRequestVisualUpdate)
@@ -54,7 +58,7 @@ export class RenderCanvas
       clearHandleEvents()
       clearDrawFrame()
     }
-    this.nativeEventBinding = new DOMEventBinding()
+    this.nativeEventBinding = binding ?? new DOMEventBinding()
     this.nativeEventBinding.onEvents = () => {
       this.frameScheduler.scheduleFrame()
     }
@@ -128,6 +132,7 @@ export class RenderCanvas
     this.markLayoutDirty()
     this.markPaintDirty()
   }
+
   private _el?: CrossPlatformCanvasElement
 
   private drawFrame = () => {


### PR DESCRIPTION
Hello! 您好

This builds on my work in https://github.com/alibaba/canvas-ui/pull/31, I suggest you will want to look at the last commit to understand this PR.  When that other PR is merged I will update this PR and remove the draft designation.

This commit adds support for injecting custom event bindings into RenderCanvas
and introduces BridgeEventBinding for programmatic event injection.

Changes:
- Add binding parameter to RenderCanvas constructor (defaults to DOMEventBinding)
- Add binding parameter to createElement factory function
- Implement BridgeEventBinding for programmatic event injection
- Add NativeEventBinding.el property for element binding
- Add comprehensive test suite for BridgeEventBinding (12 tests)

Benefits:
- Enables WebXR controller event injection
- Clean interface using property setter pattern