### PR TITLE
fix(RenderCircle): auto-set size to diameter for correct bounding box

### DIFF
--- a/packages/core/src/rendering/render-circle.ts
+++ b/packages/core/src/rendering/render-circle.ts
@@ -18,8 +18,11 @@ export class RenderCircle extends RenderShape {
   protected handleRadiusChange(value: StyleMap['radius']) {
     if (value) {
       this.radius = value
+      // Set size to diameter so bounding box is correct and consistent with Rect/RRect
+      this.size = { width: value * 2, height: value * 2 }
     } else {
       this.radius = 0
+      this.size = { width: 0, height: 0 }
     }
   }
 

--- a/packages/storybook/stories/render-circle.stories.tsx
+++ b/packages/storybook/stories/render-circle.stories.tsx
@@ -33,8 +33,7 @@ export const RenderCircleTest: StoryObj<React.FC> = () => {
       const a = createElement('Flex')
       canvas.child = a
       const b = createElement('Circle')
-      b.style.width = 100
-      b.style.height = 100
+      b.radius = 50 // Auto-sets width/height to 100x100
       b.repaintBoundary = true
       a.appendChild(b)
       const c = createElement('Circle')
@@ -51,7 +50,7 @@ export const RenderCircleTest: StoryObj<React.FC> = () => {
       const frameCallbacks: readonly FrameCallback[] = [
         // 0: initial frame
         () => {
-          b.style.height = 100
+          // b already has radius=50, so height is already 100
           b.fill = '#EFEFEF'
           b.style.boxShadow = '12px 12px 2px rgba(0, 0, 255, .2)'
 
@@ -66,7 +65,8 @@ export const RenderCircleTest: StoryObj<React.FC> = () => {
           d.radius = 0
         },
         () => {
-          b.style.height = undefined
+          // Test resetting b's radius to 0
+          b.radius = 0
           d.radius = 40
         }
       ]


### PR DESCRIPTION
Hello! 您好

I ran into this while attempting to create a slider component.

This PR fixes RenderCircle to automatically set its size (width/height) to the diameter (radius * 2) when the radius property is set, ensuring the bounding box is correct and consistent with RenderRect and RenderRRect.

## Changes:
- RenderCircle.handleRadiusChange(): automatically sets size to diameter when radius is set, or to 0x0 when radius is 0
- Updated render-circle.stories.tsx to use radius API instead of manually setting width/height

## Benefits:
- Bounding box now correctly matches the visual circle size
- Consistent behavior with other shape components (Rect, RRect)
- Simplifies usage - users only need to set radius, not width/height